### PR TITLE
Remove private index for azureml-open-datasets

### DIFF
--- a/01_Data_Preparation/01_Data_Preparation.ipynb
+++ b/01_Data_Preparation/01_Data_Preparation.ipynb
@@ -81,7 +81,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install azureml-opendatasets==0.1.0.8487238 --extra-index-url https://azuremlsdktestpypi.azureedge.net/CLI-SDK-Runners-Validation/8487238/"
+    "!pip install azureml-opendatasets"
    ]
   },
   {


### PR DESCRIPTION
Remove private pypi index for azureml-open-datasets since the one on pypi has the changes we need.