### PR TITLE
Updated git clone from KM to Many Models repo

### DIFF
--- a/EnvironmentSetup.md
+++ b/EnvironmentSetup.md
@@ -25,5 +25,5 @@ To clone this git repository onto the workspace, follow the steps below:
 
 1. In the terminal window clone this repository by typing:
 ```
-        git clone https://github.com/microsoft/solution-accelerator-km-aml.git
+        git clone https://github.com/microsoft/solution-accelerator-many-models.git
 ```


### PR DESCRIPTION
The URL in the "git clone" command was for the Knowledge Mining Solution Accelerator. Updated to use the URL for the Many Models Solution Accelerator instead.