### PR TITLE
Train-test split in training and inference set in forecasting

### DIFF
--- a/Automated_ML/02b_Train_AutoML/02b_Train_AutoML.ipynb
+++ b/Automated_ML/02b_Train_AutoML/02b_Train_AutoML.ipynb
@@ -319,7 +319,7 @@
     "    \"verbosity\" : logging.INFO, \n",
     "    \"debug_log\": 'automl_oj_sales_debug.txt',\n",
     "    \"time_column_name\": 'WeekStarting',\n",
-    "    \"max_horizon\" : 6,\n",
+    "    \"max_horizon\" : 20,\n",
     "    \"group_column_names\": ['Store', 'Brand'],\n",
     "    \"grain_column_names\": ['Store', 'Brand'],\n",
     "    \"drop_column_names\": ['Revenue']\n",

--- a/Custom_Script/01_Data_Preparation.ipynb
+++ b/Custom_Script/01_Data_Preparation.ipynb
@@ -89,7 +89,9 @@
    "source": [
     "## 3.0 Create Datasets\n",
     "\n",
-    "This solution accelerator uses simulated orange juice weekly sales data from [Azure Open Datasets](https://azure.microsoft.com/en-us/services/open-datasets/) to walk you through the process of training many models on Azure Machine Learning. You can learn more about the dataset [here](https://azure.microsoft.com/en-us/services/open-datasets/catalog/sample-oj-sales-simulated/). The full dataset includes simulared sales for 3,991 stores with 3 orange juice brands each thus allowing 11,973 models to be trained to showcase the power of the many models pattern.\n",
+    "This solution accelerator uses simulated orange juice weekly sales data from [Azure Open Datasets](https://azure.microsoft.com/en-us/services/open-datasets/) to walk you through the process of training many models on Azure Machine Learning. You can learn more about the dataset [here](https://azure.microsoft.com/en-us/services/open-datasets/catalog/sample-oj-sales-simulated/). \n",
+    "\n",
+    "The full dataset includes simulared sales for 3,991 stores with 3 orange juice brands each thus allowing 11,973 models to be trained to showcase the power of the many models pattern. Each series contains data from '1990-06-14' to '1992-10-01'.\n",
     "\n",
     "We'll start by downloading the first 10 files but you can easily edit the code below to train all 11,973 models."
    ]
@@ -120,7 +122,7 @@
     "oj_sales_files_small = OjSalesSimulated.get_file_dataset().take(10)\n",
     "\n",
     "# Create a folder to download\n",
-    "target_path = 'oj_sales_data_2' \n",
+    "target_path = 'oj_sales_data' \n",
     "if not os.path.exists(target_path):\n",
     "    os.mkdir(target_path)\n",
     "\n",
@@ -132,7 +134,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now create a train/test split for each dataset and upload both sets of data files to your default Workspace [Datastore](https://docs.microsoft.com/en-us/python/api/azureml-core/azureml.core.datastore(class)?view=azure-ml-py). The test files will contain the last 20 weeks of observations from each original data file. In order to ensure the splitting respects temporal ordering, we need to provide the name of the timestamp column. Finally, both train and test files are uploaded to the Datastore.  "
+    "We will now split each dataset in two parts: one will be used for training in the [training notebook](02_Training_Pipeline.ipynb), and the other will be used for simulating batch inferencing in the [forecasting notebook](03_Forecasting_Pipeline.ipynb). The training files will contain the data records before '1992-5-28' and the last part of each series will be stored in the inferencing files.\n",
+    "\n",
+    "Finally, we will upload both sets of data files to the Workspace's default [Datastore](https://docs.microsoft.compython/api/azureml-core/azureml.core.datastore(class))."
    ]
   },
   {
@@ -146,25 +150,25 @@
     "# Connect to default datastore\n",
     "datastore = ws.get_default_datastore()\n",
     "\n",
-    "# Set upload paths for train and test splits\n",
+    "# Set upload paths for train and inference splits\n",
     "ds_train_path = target_path + '_train'\n",
-    "ds_test_path = target_path + '_test'\n",
+    "ds_inference_path = target_path + '_inference'\n",
     "\n",
-    "# Provide name of timestamp column in the data and number of periods to reserve for the test set\n",
+    "# Provide name of timestamp column in the data and date from which to split into the inference dataset\n",
     "timestamp_column = 'WeekStarting'\n",
-    "n_test_periods = 20\n",
+    "split_date = '1992-05-28'\n",
     "\n",
     "# Split each file and upload both sets to the datastore \n",
-    "split_data_upload_to_datastore(target_path, timestamp_column, n_test_periods, datastore, ds_train_path, ds_test_path)"
+    "split_data_upload_to_datastore(target_path, timestamp_column, split_date, datastore, ds_train_path, ds_inference_path)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we create and register [datasets](https://docs.microsoft.com/en-us/azure/machine-learning/concept-data#datasets) in Azure Machine Learning for the train and test sets. \n",
+    "Next, we create and register [datasets](https://docs.microsoft.com/en-us/azure/machine-learning/concept-data#datasets) in Azure Machine Learning for the train and inference sets. \n",
     "\n",
-    "Using a [FileDataset](https://docs.microsoft.com/en-us/python/api/azureml-core/azureml.data.file_dataset.filedataset?view=azure-ml-py) is currently the best way to take advantage of the many models pattern so we create FileDatasets in the next cell. We also [register](https://docs.microsoft.com/en-us/azure/machine-learning/how-to-create-register-datasets#register-datasets) the Datasets in your Workspace; this associates the train/test sets with simple names that can be easily referred to later on when we train models and produce forecasts. "
+    "Using a [FileDataset](https://docs.microsoft.com/en-us/python/api/azureml-core/azureml.data.file_dataset.filedataset?view=azure-ml-py) is currently the best way to take advantage of the many models pattern so we create FileDatasets in the next cell. We also [register](https://docs.microsoft.com/en-us/azure/machine-learning/how-to-create-register-datasets#register-datasets) the Datasets in your Workspace; this associates the train/inference sets with simple names that can be easily referred to later on when we train models and produce forecasts. "
    ]
   },
   {
@@ -175,21 +179,21 @@
    "source": [
     "# Create file datasets\n",
     "ds_train = Dataset.File.from_files(path=datastore.path(ds_train_path), validate=False)\n",
-    "ds_test = Dataset.File.from_files(path=datastore.path(ds_test_path), validate=False)\n",
+    "ds_inference = Dataset.File.from_files(path=datastore.path(ds_inference_path), validate=False)\n",
     "\n",
     "# Register the file datasets\n",
     "dataset_name = 'oj_data_small'\n",
     "train_dataset_name = dataset_name + '_train'\n",
-    "test_dataset_name = dataset_name + '_test'\n",
+    "inference_dataset_name = dataset_name + '_inference'\n",
     "ds_train.register(ws, train_dataset_name, create_new_version=True)\n",
-    "ds_test.register(ws, test_dataset_name, create_new_version=True)"
+    "ds_inference.register(ws, inference_dataset_name, create_new_version=True)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that you've set up your Workspace and created Datasets, move on to 02_Training_Pipeline.ipynb to train the models."
+    "Now that you've set up your Workspace and created Datasets, move on to 02_Training_Pipeline.ipynb to train and score the models."
    ]
   }
  ],

--- a/Custom_Script/02_Training_Pipeline.ipynb
+++ b/Custom_Script/02_Training_Pipeline.ipynb
@@ -283,7 +283,7 @@
     "               '--timeseries_id_columns', 'Store', 'Brand',\n",
     "               '--drop_columns', 'Revenue', 'Store', 'Brand',\n",
     "               '--model_type', 'lr',\n",
-    "               '--test_proportion', 0.3]\n",
+    "               '--test_size', 6]\n",
     ")"
    ]
   },

--- a/Custom_Script/02_Training_Pipeline.ipynb
+++ b/Custom_Script/02_Training_Pipeline.ipynb
@@ -283,7 +283,7 @@
     "               '--timeseries_id_columns', 'Store', 'Brand',\n",
     "               '--drop_columns', 'Revenue', 'Store', 'Brand',\n",
     "               '--model_type', 'lr',\n",
-    "               '--test_size', 6]\n",
+    "               '--test_size', 20]\n",
     ")"
    ]
   },

--- a/Custom_Script/02_Training_Pipeline.ipynb
+++ b/Custom_Script/02_Training_Pipeline.ipynb
@@ -17,7 +17,7 @@
     "---\n",
     "This notebook demonstrates how to create a pipeline that trains and registers many models. We utilize the [ParallelRunStep](https://docs.microsoft.com/en-us/azure/machine-learning/how-to-use-parallel-run-step) to parallelize the process of training the models to make the process more efficient. For this solution accelerator we are using the [OJ Sales Dataset](https://azure.microsoft.com/en-us/services/open-datasets/catalog/sample-oj-sales-simulated/) to train individual models that predict sales for each store and brand of orange juice.\n",
     "\n",
-    "The model we use here is a simple, regression-based forecaster built on scikit-learn and pandas utilities. See the [training script](scripts/train.py) to see how the forecaster is constructed. This forecaster is intended for demonstration purposes, so it does not handle the large variety of special cases that one encounters in time-series modeling. For instance, the model here assumes that all time-series are comprised of regularly sampled observations on a contiguous interval with no missing values. The model does not include any handling of categorical variables. For a more general-use forecaster that handles missing data, advanced featurization, and automatic model selection, see the [AutoML Forecasting task](https://docs.microsoft.com/en-us/azure/machine-learning/how-to-auto-train-forecast). Also, see the notebooks demonstrating [AutoML forecasting in a many models scenario](../Automated_ML). \n",
+    "The model we use here is a simple, regression-based forecaster built on scikit-learn and pandas utilities. See the [training script](scripts/train.py) to see how the forecaster is constructed. This forecaster is intended for demonstration purposes, so it does not handle the large variety of special cases that one encounters in time-series modeling. For instance, the model here assumes that all time-series are comprised of regularly sampled observations on a contiguous interval with no missing values. The model does not include any handling of categorical variables. For a more general-use forecaster that handles missing data, advanced featurization, and automatic model selection, see the [AutoML Forecasting task](https://docs.microsoft.com/en-us/azure/machine-learning/how-to-auto-train-forecast). Also, see the notebooks demonstrating [AutoML forecasting in a many models scenario](../Automated_ML).\n",
     "\n",
     "### Prerequisites\n",
     "At this point, you should have already:\n",
@@ -259,7 +259,7 @@
     "\n",
     "- **output**: A PipelineData object that corresponds to the output directory. We'll use the output directory we just defined. \n",
     "\n",
-    "- **arguments**: A list of arguments required for the train.py entry script. Here, we provide the schema for the timeseries data - i.e. the names of target, timestamp, and id columns - as well as columns that should be dropped prior to modeling and a string identifying the model type."
+    "- **arguments**: A list of arguments required for the train.py entry script. Here, we provide the schema for the timeseries data - i.e. the names of target, timestamp, and id columns - as well as columns that should be dropped prior to modeling, a string identifying the model type, and the proportion of data we want to leave aside for testing."
    ]
   },
   {
@@ -282,7 +282,9 @@
     "               '--timestamp_column', 'WeekStarting', \n",
     "               '--timeseries_id_columns', 'Store', 'Brand',\n",
     "               '--drop_columns', 'Revenue', 'Store', 'Brand',\n",
-    "               '--model_type', 'lr'])"
+    "               '--model_type', 'lr',\n",
+    "               '--test_proportion', 0.3]\n",
+    ")"
    ]
   },
   {
@@ -290,7 +292,7 @@
    "metadata": {},
    "source": [
     "## 5.0 Run the pipeline\n",
-    "Next, we submit our pipeline to run. The run will train models for each dataset and compute **in-sample** accuracy metrics for the fits. With 10 files, this should only take a few minutes but with the full dataset this can take over an hour."
+    "Next, we submit our pipeline to run. The run will train models for each dataset using a train set, compute accuracy metrics for the fits using a test set, and finally re-train models with all the data available. With 10 files, this should only take a few minutes but with the full dataset this can take over an hour."
    ]
   },
   {
@@ -302,8 +304,7 @@
     "from azureml.pipeline.core import Pipeline\n",
     "\n",
     "pipeline = Pipeline(workspace=ws, steps=[parallel_run_step])\n",
-    "run = experiment.submit(pipeline,tags=tags)\n",
-    "run.wait_for_completion(show_output=True)"
+    "run = experiment.submit(pipeline, tags=tags)"
    ]
   },
   {
@@ -335,13 +336,11 @@
    "source": [
     "import os\n",
     "\n",
-    "def download_results(run, target_dir=None):\n",
-    "    stitch_run = run.find_step_run(\"many-models-training\")[0]\n",
-    "    port_data = stitch_run.get_output_data(\"training_output\")\n",
-    "    print(port_data)\n",
+    "def download_results(run, target_dir=None, step_name='many-models-training', output_name='training_output'):\n",
+    "    stitch_run = run.find_step_run(step_name)[0]\n",
+    "    port_data = stitch_run.get_output_data(output_name)\n",
     "    port_data.download(target_dir, show_progress=True)\n",
-    "    step_hash = os.listdir(os.path.join(target_dir, 'azureml'))[0]\n",
-    "    return  os.path.join(target_dir, 'azureml', step_hash, 'training_output')\n",
+    "    return os.path.join(target_dir, 'azureml', stitch_run.id, output_name)\n",
     "\n",
     "file_path = download_results(run, 'output')\n",
     "file_path"
@@ -420,7 +419,7 @@
    "source": [
     "### 6.4 Visualize Performance across models\n",
     "\n",
-    "Here, we produce some charts from the errors metrics calculated during the run. It is important to note that these metrics are computed over the training data - that is, they're in-sample metrics - and, therefore, may not reflect true forecasting accuracy. Please see the [forecasting notebook](03_Forecasting_Pipeline.ipynb) for an example of out-of-sample evaluation that is more appropriate for assessing forecast accuracy.\n",
+    "Here, we produce some charts from the errors metrics calculated during the run using a subset put aside for testing.\n",
     "\n",
     "First, we examine the distribution of mean absolute percentage error (MAPE) over all the models:"
    ]
@@ -562,7 +561,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/Custom_Script/03_Forecasting_Pipeline.ipynb
+++ b/Custom_Script/03_Forecasting_Pipeline.ipynb
@@ -105,7 +105,7 @@
    "metadata": {},
    "source": [
     "## 3.0 Get the dataset\n",
-    "Now we get a reference to the test data in our Datastore. We will use the models trained in the Modeling Notebook to generate forecasts over all rows in each test set."
+    "Now we get a reference to the inference data in our Datastore. We will use the models trained in the Modeling Notebook to generate forecasts over all rows in each file."
    ]
   },
   {
@@ -118,7 +118,7 @@
    "source": [
     "from azureml.core.dataset import Dataset\n",
     "\n",
-    "small_dataset = Dataset.get_by_name(ws, name='oj_data_small_test')\n",
+    "small_dataset = Dataset.get_by_name(ws, name='oj_data_small_inference')\n",
     "small_dataset_input = small_dataset.as_named_input('forecast_10_models')"
    ]
   },
@@ -127,7 +127,9 @@
    "metadata": {},
    "source": [
     "## 4.0 Create ParallelRunStep for the forecasting pipeline\n",
-    "As we did with the training pipeline, we'll create a ParallelRunStep to parallelize our forecasting process. You'll notice this code is essentially the same as the last step except that we'll be parallelizing [**forecast.py**](scripts/forecast.py) rather than train.py. Note that we still need to pass the timeseries schema (timestamp column name, timeseries ID column names, etc) to the forecasting script. Unlike the training script, however, the name of target column is not required for the forecasting script, just optional. In a true forecasting scenario the actual values of the target are not available, of course, so the forecasting pipeline would just return predictions. In a testing scenario, the forecasting pipeline can also return the actuals, if the column name is provided, so that we may evaluate the accuracy of the forecasts on a hold-out set.\n",
+    "As we did with the training pipeline, we'll create a ParallelRunStep to parallelize our forecasting process. You'll notice this code is essentially the same as the last step except that we'll be parallelizing [**forecast.py**](scripts/forecast.py) rather than train.py. Note that we still need to pass the timeseries schema (timestamp column name, timeseries ID column names, etc) to the forecasting script.\n",
+    "\n",
+    "Unlike the training script, however, the name of target column is not required for the forecasting script. In a true forecasting scenario the actual values of the target are not available, of course, so the forecasting pipeline would just return predictions. However, the forecasting pipeline can also return the actuals if they are present in the inference dataset.\n",
     "\n",
     "### 4.1 Configure environment for ParallelRunStep"
    ]
@@ -229,8 +231,7 @@
     "    inputs=[small_dataset_input],\n",
     "    output=output_dir,\n",
     "    allow_reuse=False,\n",
-    "    arguments=['--target_column', 'Quantity',  # Since this is a testing scenario, pass the target column name\n",
-    "               '--timestamp_column', 'WeekStarting',\n",
+    "    arguments=['--timestamp_column', 'WeekStarting',\n",
     "               '--timeseries_id_columns', 'Store', 'Brand',\n",
     "               '--model_type', 'lr']\n",
     ")"
@@ -275,7 +276,7 @@
    "metadata": {},
    "source": [
     "### 5.2 Create PythonScriptStep\n",
-    "Next, we define the [PythonScriptStep](https://docs.microsoft.com/en-us/python/api/azureml-pipeline-steps/azureml.pipeline.steps.python_script_step.pythonscriptstep?view=azure-ml-py) and give it our newly create datastore as well as the location of the *parallel_run_step.txt*. Note that the copy script also uses the timeseries schema; the reason is that the copy script creates a header row for the prediction data and, thus, needs to know the column names. The target column is passed here only if it was also passed to the forecasting script."
+    "Next, we define the [PythonScriptStep](https://docs.microsoft.com/en-us/python/api/azureml-pipeline-steps/azureml.pipeline.steps.python_script_step.pythonscriptstep?view=azure-ml-py) and give it our newly create datastore as well as the location of the *parallel_run_step.txt*. Note that the copy script also uses the timeseries schema; the reason is that the copy script creates a header row for the prediction data and, thus, needs to know the column names. The target column is passed here since it was present in the data used for inferencing."
    ]
   },
   {
@@ -297,7 +298,7 @@
     "               '--output_dir', output_dref,\n",
     "               '--target_column', 'Quantity',\n",
     "               '--timestamp_column', 'WeekStarting',\n",
-    "               '--timeseries_id_columns', 'Store', 'Brand',]\n",
+    "               '--timeseries_id_columns', 'Store', 'Brand']\n",
     ")"
    ]
   },
@@ -319,8 +320,7 @@
     "from azureml.pipeline.core import Pipeline\n",
     "\n",
     "pipeline = Pipeline(workspace=ws, steps=[parallel_run_step, upload_predictions_step])\n",
-    "run = experiment.submit(pipeline, tags=tags)\n",
-    "run.wait_for_completion(show_output=True)"
+    "run = experiment.submit(pipeline, tags=tags)"
    ]
   },
   {
@@ -366,13 +366,11 @@
     "import os\n",
     "from pathlib import Path\n",
     "\n",
-    "def download_predictions(run, target_dir=None):\n",
-    "    stitch_run = run.find_step_run(\"many-models-forecasting\")[0]\n",
-    "    port_data = stitch_run.get_output_data('forecasting_output')\n",
-    "    print(port_data)\n",
+    "def download_predictions(run, target_dir=None, step_name='many-models-forecasting', output_name='forecasting_output'):\n",
+    "    stitch_run = run.find_step_run(step_name)[0]\n",
+    "    port_data = stitch_run.get_output_data(output_name)\n",
     "    port_data.download(target_dir, show_progress=True, overwrite=True)\n",
-    "    latest = sorted(Path(os.path.join(target_dir, 'azureml')).iterdir(), key=os.path.getmtime)\n",
-    "    return  os.path.join(latest[-1], 'forecasting_output')\n",
+    "    return os.path.join(target_dir, 'azureml', stitch_run.id, output_name)\n",
     "\n",
     "file_path = download_predictions(run, 'output')\n",
     "file_path"
@@ -396,7 +394,6 @@
     "df = pd.read_csv(file_path + '/parallel_run_step.txt', sep=\" \", header=None)\n",
     "df.columns = ['WeekStarting', 'Predictions', 'Quantity', 'Store', 'Brand']\n",
     "df['WeekStarting'] = pd.to_datetime(df['WeekStarting'])\n",
-    "# df['WeekStarting'] = [d.date() for d in pd.to_datetime(df['WeekStarting'])]\n",
     "df.head()"
    ]
   },
@@ -475,50 +472,6 @@
     "plt.title('Predictions for Store 1001')\n",
     "plt.xlabel('Week')\n",
     "plt.ylabel('Predicted Quantity')\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Since we produced forecasts on a test set, we can also examine forecast errors. The next plot displays the distribution of absolute percentage errors for each date in the testing period. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "\n",
-    "# Compute the absolute percentage error for each forecast at each date\n",
-    "# Warning: percentage errors are not defined if the actuals contain zero values\n",
-    "df['APE'] = 100*np.abs((df['Quantity'].values - df['Predictions'].values) / df['Quantity'].values)\n",
-    "\n",
-    "fig = sns.boxplot(x='WeekStarting', y='APE', data=df)\n",
-    "fig.set_title('Absolute Percentage Error Distributions Over All Stores and Brands')\n",
-    "plt.gcf().set_size_inches(15.0, 6.0)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "It is also useful to see the error distributions broken down by store and brand. Here, the boxplots show the distribution of errors over time in the forecast period for each series in the dataset."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = sns.boxplot(x='Store', y='APE', hue='Brand', data=df)\n",
-    "fig.set_title('Absolute Percentage Errors by Store and Brand')\n",
-    "plt.gcf().set_size_inches(15.0, 6.0)\n",
     "plt.show()"
    ]
   },

--- a/Custom_Script/scripts/forecast.py
+++ b/Custom_Script/scripts/forecast.py
@@ -1,18 +1,16 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import numpy as np
-import pandas as pd
-import os
 import argparse
 import joblib
-from sklearn.metrics import mean_squared_error, mean_absolute_error
+import pandas as pd
+
 from azureml.core.model import Model
 from azureml.core.run import Run
 
+
 # 0.0 Parse input arguments
 parser = argparse.ArgumentParser("split")
-parser.add_argument("--target_column", type=str, help="target colunm to predict on", default=None)
 parser.add_argument("--timestamp_column", type=str, help="timestamp column from data", required=True)
 parser.add_argument("--timeseries_id_columns", type=str, nargs='*', required=True,
                     help="input columns identifying the timeseries")
@@ -33,15 +31,13 @@ def run(input_data):
     results = []
 
     # 2.0 Iterate through input data
-    for idx, csv_file_path in enumerate(input_data):
-        file_name = os.path.basename(csv_file_path)[:-4]
-        model_name = args.model_type + '_' + file_name
+    for csv_file_path in input_data:
 
         # 3.0 Set up data to predict on
         data = (pd.read_csv(csv_file_path, parse_dates=[args.timestamp_column], header=0)
                 .set_index(args.timestamp_column))
 
-        # 4.0 Unpickle model and make predictions
+        # 4.0 Load registered model from Workspace
         ts_id_dict = {id_col: str(data[id_col].iloc[0]) for id_col in args.timeseries_id_columns}
         tag_list = [list(kv) for kv in ts_id_dict.items()]
         tag_list.append(['ModelType', args.model_type])
@@ -51,28 +47,16 @@ def run(input_data):
             raise ValueError("More than one models encountered for given timeseries id")
         model_path = models[0].download()
         forecaster = joblib.load(model_path)
+
+        # 5.0 Make predictions
         forecasts = forecaster.forecast(data)
         prediction_df = forecasts.to_frame(name='Prediction')
+        
+        # 6.0 Add actuals to the returned dataframe if they are available
+        if forecaster.target_column_name in data.columns:
+            prediction_df[forecaster.target_column_name] = data[forecaster.target_column_name]
 
-        # 5.0 If actuals are passed in with data, compute accuracy metrics and log in the Run
-        # Also add actuals to the returned dataframe if they are available
-        if args.target_column is not None and args.target_column in data.columns:
-            compare_data = data.assign(forecasts=forecasts)
-            mse = mean_squared_error(compare_data[args.target_column], compare_data['forecasts'])
-            rmse = np.sqrt(mse)
-            mae = mean_absolute_error(compare_data[args.target_column], compare_data['forecasts'])
-            actuals = compare_data[args.target_column].values
-            preds = compare_data['forecasts'].values
-            mape = np.mean(np.abs((actuals - preds) / actuals) * 100)
-
-            current_run.log(model_name + '_mse', mse)
-            current_run.log(model_name + '_rmse', rmse)
-            current_run.log(model_name + '_mae', mae)
-            current_run.log(model_name + '_mape', mape)
-
-            prediction_df[args.target_column] = data[args.target_column]
-
-        # 6.0 Add the timeseries id columns and append the dataframe to the return list
+        # 7.0 Add the timeseries id columns and append the dataframe to the return list
         results.append(prediction_df.reset_index().assign(**ts_id_dict))
 
     # Data returned by this function will be available in parallel_run_step.txt

--- a/Custom_Script/scripts/helper.py
+++ b/Custom_Script/scripts/helper.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 import os
-import glob
 import pandas as pd
 
 
@@ -22,7 +21,7 @@ def split_data_upload_to_datastore(data_path, time_column_name, split_date, data
     os.makedirs(inference_data_path, exist_ok=True)
 
     files_list = [os.path.join(path, f) for path, _, files in os.walk(data_path) for f in files
-                  if not path in (train_data_path, inference_data_path)]
+                  if path not in (train_data_path, inference_data_path)]
 
     for file in files_list:
         file_name = os.path.basename(file)

--- a/Custom_Script/scripts/helper.py
+++ b/Custom_Script/scripts/helper.py
@@ -3,32 +3,8 @@
 
 import os
 import glob
-import sys
 import pandas as pd
-sys.path.append("..")
 
-
-def build_parallel_run_config_for_forecasting(train_env, compute, nodecount, workercount, timeout):
-    from azureml.pipeline.steps import ParallelRunConfig
-    from common.scripts.helper import validate_parallel_run_config
-    parallel_run_config = ParallelRunConfig(
-        source_directory='./scripts',
-        entry_script='forecast.py',
-        mini_batch_size="1",  # do not modify this setting
-        run_invocation_timeout=timeout,
-        error_threshold=10,
-        output_action="append_row",
-        environment=train_env,
-        process_count_per_node=workercount,
-        compute_target=compute,
-        node_count=nodecount)
-    validate_parallel_run_config(parallel_run_config)
-    return parallel_run_config
-
-
-def get_automl_environment():
-    from common.scripts.helper import get_automl_environment as get_env
-    return get_env()
 
 def upload_to_datastore(datastore, source_path, target_path):
     datastore.upload(src_dir=source_path,
@@ -36,43 +12,42 @@ def upload_to_datastore(datastore, source_path, target_path):
                      overwrite=True,
                      show_progress=False)
 
-def split_data_upload_to_datastore(data_path, time_column_name, ntest_periods, datastore, train_ds_target_path,
-                                   test_ds_target_path):
-    train_data_path = data_path + "/upload_train_data"
-    test_data_path = data_path + "/upload_test_data"
-    if not os.path.exists(train_data_path):
-        os.makedirs(train_data_path)
-    if not os.path.exists(test_data_path):
-        os.makedirs(test_data_path)
 
-    files_list = [f for f in set(glob.glob(os.path.join(data_path, "**"), recursive=True)) -
-                  set(glob.glob(os.path.join(data_path, "upload_**"), recursive=True))
-                  if os.path.isfile(f)]
+def split_data_upload_to_datastore(data_path, time_column_name, split_date, datastore, train_ds_target_path,
+                                   inference_ds_target_path):
+
+    train_data_path = os.path.join(data_path, "upload_train_data")
+    inference_data_path = os.path.join(data_path, "upload_inference_data")
+    os.makedirs(train_data_path, exist_ok=True)
+    os.makedirs(inference_data_path, exist_ok=True)
+
+    files_list = [os.path.join(path, f) for path, _, files in os.walk(data_path) for f in files
+                  if not path in (train_data_path, inference_data_path)]
 
     for file in files_list:
         file_name = os.path.basename(file)
-        file_extension = os.path.splitext(file_name)[1]
-        if file_extension.lower() == ".parquet":
-            df = pd.read_parquet(file)
-        else:
-            df = pd.read_csv(file)
+        file_extension = os.path.splitext(file_name)[1].lower()
+        df = read_file(file, file_extension)
 
-        df.reset_index(drop=True, inplace=True)
-        df[time_column_name] = pd.to_datetime(df[time_column_name])
-        df.sort_values(time_column_name, ascending=True, inplace=True)
-        train_df = df.iloc[:-ntest_periods].copy()
-        test_df = df.iloc[-ntest_periods:].copy()
+        before_split_date = df[time_column_name] < split_date
+        train_df, inference_df = df[before_split_date], df[~before_split_date]
 
-        if file_extension.lower() == ".parquet":
-            train_df.to_parquet(os.path.join(train_data_path, "{}".format(
-                file_name)))
-            test_df.to_parquet(os.path.join(test_data_path, "{}".format(
-                file_name)))
-        else:
-            train_df.to_csv(os.path.join(train_data_path, "{}".format(
-                file_name)), index=None, header=True)
-            test_df.to_csv(os.path.join(test_data_path, "{}".format(
-                file_name)), index=None, header=True)
+        write_file(train_df, os.path.join(train_data_path, file_name), file_extension)
+        write_file(inference_df, os.path.join(inference_data_path, file_name), file_extension)
 
     upload_to_datastore(datastore, train_data_path, train_ds_target_path)
-    upload_to_datastore(datastore, test_data_path, test_ds_target_path)
+    upload_to_datastore(datastore, inference_data_path, inference_ds_target_path)
+
+
+def read_file(path, extension):
+    if extension == ".parquet":
+        return pd.read_parquet(path)
+    else:
+        return pd.read_csv(path)
+
+
+def write_file(data, path, extension):
+    if extension == ".parquet":
+        data.to_parquet(path)
+    else:
+        data.to_csv(path, index=None, header=True)

--- a/Custom_Script/scripts/timeseries_utilities.py
+++ b/Custom_Script/scripts/timeseries_utilities.py
@@ -31,7 +31,7 @@ class SimpleCalendarFeaturizer(TransformerMixin, BaseEstimator):
         return self
 
     def transform(self, X):
-        return X.assign(Week_Year=X.index.weekofyear.values)
+        return X.assign(Week_Year=X.index.isocalendar().week.values)
 
 
 class SimpleLagger(TransformerMixin, BaseEstimator):

--- a/Custom_Script/scripts/train.py
+++ b/Custom_Script/scripts/train.py
@@ -24,7 +24,7 @@ parser.add_argument("--timeseries_id_columns", type=str, nargs='*', required=Tru
 parser.add_argument("--drop_columns", type=str, nargs='*', default=[],
                     help="list of columns to drop prior to modeling")
 parser.add_argument("--model_type", type=str, required=True, help="input model type")
-parser.add_argument("--test_proportion", type=float, default=0.3, help="proportion of data to be used for testing")
+parser.add_argument("--test_size", type=int, required=True, help="number of observations to be used for testing")
 
 args, _ = parser.parse_known_args()
 
@@ -56,9 +56,8 @@ def run(input_data):
                 .sort_index(ascending=True))
 
         # 2.0 Split the data into train and test sets
-        nrows_test = int(len(data) * args.test_proportion)
-        train = data[:-nrows_test]
-        test = data[-nrows_test:]
+        train = data[:-args.test_size]
+        test = data[-args.test_size:]
 
         # 3.0 Create and fit the forecasting pipeline
         # The pipeline will drop unhelpful features, make a calendar feature, and make lag features

--- a/Custom_Script/scripts/train.py
+++ b/Custom_Script/scripts/train.py
@@ -8,8 +8,10 @@ import os
 import argparse
 import datetime
 import joblib
+
 from sklearn.metrics import mean_squared_error, mean_absolute_error
 from sklearn.linear_model import LinearRegression
+
 from timeseries_utilities import ColumnDropper, SimpleLagger, SimpleCalendarFeaturizer, SimpleForecaster
 
 
@@ -19,9 +21,10 @@ parser.add_argument("--target_column", type=str, required=True, help="input targ
 parser.add_argument("--timestamp_column", type=str, required=True, help="input timestamp column")
 parser.add_argument("--timeseries_id_columns", type=str, nargs='*', required=True,
                     help="input columns identifying the timeseries")
-parser.add_argument("--model_type", type=str, required=True, help="input model type")
 parser.add_argument("--drop_columns", type=str, nargs='*', default=[],
                     help="list of columns to drop prior to modeling")
+parser.add_argument("--model_type", type=str, required=True, help="input model type")
+parser.add_argument("--test_proportion", type=float, default=0.3, help="proportion of data to be used for testing")
 
 args, _ = parser.parse_known_args()
 
@@ -49,34 +52,29 @@ def run(input_data):
 
         # 1.0 Read the data from CSV - parse timestamps as datetime type and put the time in the index
         data = (pd.read_csv(csv_file_path, parse_dates=[args.timestamp_column], header=0)
-                .set_index(args.timestamp_column))
+                .set_index(args.timestamp_column)
+                .sort_index(ascending=True))
 
-        # 2.0 Create and fit the forecasting pipeline
+        # 2.0 Split the data into train and test sets
+        nrows_test = int(len(data) * args.test_proportion)
+        train = data[:-nrows_test]
+        test = data[-nrows_test:]
+
+        # 3.0 Create and fit the forecasting pipeline
         # The pipeline will drop unhelpful features, make a calendar feature, and make lag features
         lagger = SimpleLagger(args.target_column, lag_orders=[1, 2, 3, 4])
         transform_steps = [('column_dropper', ColumnDropper(args.drop_columns)),
                            ('calendar_featurizer', SimpleCalendarFeaturizer()), ('lagger', lagger)]
         forecaster = SimpleForecaster(transform_steps, LinearRegression(), args.target_column, args.timestamp_column)
-        forecaster.fit(data)
+        forecaster.fit(train)
         print('Featurized data example:')
-        print(forecaster.transform(data).head())
+        print(forecaster.transform(train).head())
 
-        # 3.0 Save the forecasting pipeline
-        joblib.dump(forecaster, filename=os.path.join('./outputs/', model_name))
+        # 4.0 Get predictions on test set
+        forecasts = forecaster.forecast(test)
+        compare_data = test.assign(forecasts=forecasts).dropna()
 
-        # 4.0 Register the model to the workspace
-        # Uses the values in the timeseries id columns from the first row of data to form tags for the model
-        current_run.upload_file(model_name, os.path.join('./outputs/', model_name))
-        ts_id_dict = {id_col: str(data[id_col].iloc[0]) for id_col in args.timeseries_id_columns}
-        tags_dict = {**ts_id_dict, 'ModelType': args.model_type}
-        current_run.register_model(model_path=model_name, model_name=model_name,
-                                   model_framework=args.model_type, tags=tags_dict)
-
-        # 5.0 Get in-sample predictions and join with actuals
-        forecasts = forecaster.forecast(data)
-        compare_data = data.assign(forecasts=forecasts).dropna()
-
-        # 6.0 Calculate accuracy metrics for the fit
+        # 5.0 Calculate accuracy metrics for the fit
         mse = mean_squared_error(compare_data[args.target_column], compare_data['forecasts'])
         rmse = np.sqrt(mse)
         mae = mean_absolute_error(compare_data[args.target_column], compare_data['forecasts'])
@@ -84,13 +82,27 @@ def run(input_data):
         preds = compare_data['forecasts'].values
         mape = np.mean(np.abs((actuals - preds) / actuals) * 100)
 
-        # 7.0 Log metrics
+        # 6.0 Log metrics
         current_run.log(model_name + '_mse', mse)
         current_run.log(model_name + '_rmse', rmse)
         current_run.log(model_name + '_mae', mae)
         current_run.log(model_name + '_mape', mape)
 
-        # 8.0 Add data to output
+        # 7.0 Train model with full dataset
+        forecaster.fit(data)
+
+        # 8.0 Save the forecasting pipeline
+        joblib.dump(forecaster, filename=os.path.join('./outputs/', model_name))
+
+        # 9.0 Register the model to the workspace
+        # Uses the values in the timeseries id columns from the first row of data to form tags for the model
+        current_run.upload_file(model_name, os.path.join('./outputs/', model_name))
+        ts_id_dict = {id_col: str(data[id_col].iloc[0]) for id_col in args.timeseries_id_columns}
+        tags_dict = {**ts_id_dict, 'ModelType': args.model_type}
+        current_run.register_model(model_path=model_name, model_name=model_name,
+                                   model_framework=args.model_type, tags=tags_dict)
+
+        # 10.0 Add data to output
         end_datetime = datetime.datetime.now()
         result.update(ts_id_dict)
         result['model_type'] = args.model_type


### PR DESCRIPTION
Main changes:
- Split original dataset by date (same as AutoML) and change references of second set to inference set (prev. test set)
- Train-test split during training. Metrics are computed on test. Extra param "test_proportion" that defaults to 0.3.
- After logging the metrics, model is retrained using the whole dataset (training part, always leaving aside inference set) and registered
- Forecasting script no longer calculates and logs metrics, it only generates predictions (as in AutoML)