### PR TITLE
Missing module reference in 02_AutoML_Training_Pipeline.ipynb

### DIFF
--- a/Automated_ML/02_AutoML_Training_Pipeline/02_AutoML_Training_Pipeline.ipynb
+++ b/Automated_ML/02_AutoML_Training_Pipeline/02_AutoML_Training_Pipeline.ipynb
@@ -244,7 +244,7 @@
    "outputs": [],
    "source": [
     "from azureml.core.compute import ComputeTarget\n",
-    "\n",
+    "from azureml.core.compute import AmlCompute\n",
     "# Choose a name for your cluster.\n",
     "amlcompute_cluster_name = \"cpucluster\"\n",
     "\n",


### PR DESCRIPTION
02_AutoML_Training_Pipeline.ipynb notebook is missing AmlCompute module import "from azureml.core.compute import AmlCompute" which is causing the notebook to fail if the compute name doesn't exist. 