### PR TITLE
Changing kernel to Python 3.6 - AzureML in all notebooks

### DIFF
--- a/00_Setup_AML_Workspace.ipynb
+++ b/00_Setup_AML_Workspace.ipynb
@@ -158,9 +158,9 @@
    }
   ],
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.6 - AzureML",
    "language": "python",
-   "name": "python3"
+   "name": "python3-azureml"
   },
   "language_info": {
    "codemirror_mode": {

--- a/01_Data_Preparation.ipynb
+++ b/01_Data_Preparation.ipynb
@@ -345,9 +345,9 @@
    }
   ],
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.6 - AzureML",
    "language": "python",
-   "name": "python3"
+   "name": "python3-azureml"
   },
   "language_info": {
    "codemirror_mode": {

--- a/Automated_ML/02_AutoML_Training_Pipeline/02_AutoML_Training_Pipeline.ipynb
+++ b/Automated_ML/02_AutoML_Training_Pipeline/02_AutoML_Training_Pipeline.ipynb
@@ -572,9 +572,9 @@
    }
   ],
   "kernelspec": {
-   "display_name": "Python 3.6",
+   "display_name": "Python 3.6 - AzureML",
    "language": "python",
-   "name": "python36"
+   "name": "python3-azureml"
   },
   "language_info": {
    "codemirror_mode": {

--- a/Automated_ML/03_AutoML_Forecasting_Pipeline/03_AutoML_Forecasting_Pipeline.ipynb
+++ b/Automated_ML/03_AutoML_Forecasting_Pipeline/03_AutoML_Forecasting_Pipeline.ipynb
@@ -402,9 +402,9 @@
    }
   ],
   "kernelspec": {
-   "display_name": "Python 3.6",
+   "display_name": "Python 3.6 - AzureML",
    "language": "python",
-   "name": "python36"
+   "name": "python3-azureml"
   },
   "language_info": {
    "codemirror_mode": {

--- a/Custom_Script/02_CustomScript_Training_Pipeline.ipynb
+++ b/Custom_Script/02_CustomScript_Training_Pipeline.ipynb
@@ -575,9 +575,9 @@
    }
   ],
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.6 - AzureML",
    "language": "python",
-   "name": "python3"
+   "name": "python3-azureml"
   },
   "language_info": {
    "codemirror_mode": {

--- a/Custom_Script/03_CustomScript_Forecasting_Pipeline.ipynb
+++ b/Custom_Script/03_CustomScript_Forecasting_Pipeline.ipynb
@@ -556,9 +556,9 @@
    }
   ],
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.6 - AzureML",
    "language": "python",
-   "name": "python3"
+   "name": "python3-azureml"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
To prevent errors in AzureML setting kernel to Python 3.6 instead of Python 3