### PR TITLE
Corrected PythonScriptStep code

### DIFF
--- a/Custom_Script/03_CustomScript_Forecasting_Pipeline.ipynb
+++ b/Custom_Script/03_CustomScript_Forecasting_Pipeline.ipynb
@@ -310,6 +310,8 @@
    "outputs": [],
    "source": [
     "from azureml.pipeline.steps import PythonScriptStep\n",
+    "from azureml.core.runconfig import RunConfiguration\n",
+    "pss_config = RunConfiguration(conda_dependencies = forecast_conda_deps) \n",
     "\n",
     "upload_predictions_step = PythonScriptStep(\n",
     "    name=\"copy_predictions\",\n",
@@ -317,6 +319,7 @@
     "    compute_target=compute,\n",
     "    source_directory='./scripts',\n",
     "    inputs=[output_dref, output_dir],\n",
+    "    runconfig = pss_config,\n",
     "    allow_reuse=False,\n",
     "    arguments=['--parallel_run_step_output', output_dir,\n",
     "               '--output_dir', output_dref,\n",


### PR DESCRIPTION
When trying to run the pipeline in 03_CustomScript_Forecasting_Pipeline.ipynb I was getting an error when the pipeline got to import pandas as pd in the copy_predictions.py script. 
I fixed the problem by changing the code in 5.2 Create PythonScriptStep 

Please refer to issue #141 